### PR TITLE
Fix for httr2 1.1.1

### DIFF
--- a/tests/testthat/test-get_iso.R
+++ b/tests/testthat/test-get_iso.R
@@ -37,7 +37,6 @@ test_that("build_iso_query works", {
    )
 
    expect_s3_class(req, "httr2_request")
-   expect_length(req, 7)
    expect_match(req$url,
                 "https://data.geopf.fr/navigation/isochrone")
    expect_equal(req$options$ssl_verifypeer, 0)


### PR DESCRIPTION
It's a bad idea to test the general properties of object that you don't create because they're not guaranteed to remain the same.